### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label-manager.yml
+++ b/.github/workflows/label-manager.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   labels:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
     - uses: actions/checkout@v4
     


### PR DESCRIPTION
Potential fix for [https://github.com/javideros/toolbox/security/code-scanning/5](https://github.com/javideros/toolbox/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow or the specific job. Since the job uses the `EndBug/label-sync@v2` action to manage labels, it requires `issues: write` permission. It is also a good practice to set `contents: read` to allow basic repository read access, which is often required for actions to function properly. The `permissions` block can be added at the workflow root (applies to all jobs) or at the job level (applies only to the `labels` job). The best practice is to add it at the job level if only that job needs the permission, but adding it at the root is also acceptable if all jobs need the same permissions. In this case, since there is only one job, either is fine, but job-level is slightly more precise.

**Required changes:**
- Add a `permissions` block under the `labels` job (line 12), specifying `contents: read` and `issues: write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
